### PR TITLE
Fix podspec to remove non-swift files from source

### DIFF
--- a/TVMultiPicker.podspec
+++ b/TVMultiPicker.podspec
@@ -16,5 +16,5 @@ Contains pre-configured date picker. Supports user defined style configuration.
 
   s.platform     = :tvos, "9.0"
   
-  s.source_files = 'TVMultiPicker/*'
+  s.source_files = 'TVMultiPicker/*.swift'
 end


### PR DESCRIPTION
Fix error while integrating into project

Error Message:
```
Multiple commands produce '../Debug-appletvsimulator/TVMultiPicker/TVMultiPicker.framework/Info.plist':
1) Target 'TVMultiPicker' (project 'Pods') has copy command from '../Pods/TVMultiPicker/TVMultiPicker/Info.plist' to '../Library/Developer/Xcode/DerivedData/Build/Products/Debug-appletvsimulator/TVMultiPicker/TVMultiPicker.framework/Info.plist'
2) Target 'TVMultiPicker' (project 'Pods') has process command with output '../Library/Developer/Xcode/DerivedData/Build/Products/Debug-appletvsimulator/TVMultiPicker/TVMultiPicker.framework/Info.plist'
```

Info.plist in TVMultiPicker causing this error